### PR TITLE
Now builds correctly under Ubuntu 17.10.

### DIFF
--- a/src/tld_emails.cpp
+++ b/src/tld_emails.cpp
@@ -982,7 +982,7 @@ tld_result tld_email_list::tld_email_t::parse(std::string const & email)
     std::string fullname;
     std::string username;
     std::string domain;
-    int count;
+    uint64_t count = 0;
     bool has_angle(false);
     bool found_at(false);
     bool found_dot(false);
@@ -1393,7 +1393,7 @@ tld_result tld_email_list::tld_email_t::parse_group(std::string const & group)
 {
     char const * s(group.c_str());
     std::string g;
-    int count;
+    uint64_t count = 0;
 
     for(; *s != '\0'; ++s)
     {

--- a/src/tld_emails.cpp
+++ b/src/tld_emails.cpp
@@ -982,7 +982,7 @@ tld_result tld_email_list::tld_email_t::parse(std::string const & email)
     std::string fullname;
     std::string username;
     std::string domain;
-    uint64_t count = 0;
+    uint32_t count = 0;
     bool has_angle(false);
     bool found_at(false);
     bool found_dot(false);
@@ -1393,7 +1393,7 @@ tld_result tld_email_list::tld_email_t::parse_group(std::string const & group)
 {
     char const * s(group.c_str());
     std::string g;
-    uint64_t count = 0;
+    uint32_t count = 0;
 
     for(; *s != '\0'; ++s)
     {

--- a/tests/tld_test_versions.c
+++ b/tests/tld_test_versions.c
@@ -251,7 +251,7 @@ void check_changelog(const char *path, const char *version)
 
     // the debian version is likely to include a build number and platform name
     i = 0;
-    for(str = debian_version; str != '\0'; ++str)
+    for(str = debian_version; *str != '\0'; ++str)
     {
         if(*str == '~')
         {


### PR DESCRIPTION
Fixed signed-overflow error by changing the counts to uint64_t. Also,
one of the tests was not dereferencing str.